### PR TITLE
Einreichung eines weiteren Artikels als Kommentar.

### DIFF
--- a/voss2/abstract.md
+++ b/voss2/abstract.md
@@ -1,0 +1,1 @@
+Der Kommentar weist auf die Bedeutung von Wikidata für die Entwicklung einer Universalbibliographie hin

--- a/voss2/bibliography.bib
+++ b/voss2/bibliography.bib
@@ -1,0 +1,45 @@
+@book{Voss2014,
+    title={Normdaten in Wikidata},
+    author={Jakob Voß and  Susanna Bausch and  Julian Schmitt and  Jasmin Bogner and  Viktoria Berkelmann and  Franziska Ludemann and  Oliver Löffel and  Janna Kitroschat and  Maiia Bartoshevska and  Katharina Seljuzki},
+    publisher={lulu.com},
+    isbn={978-1-291-85658-3},
+    url={https://hshdb.github.io/normdaten-in-wikidata/}
+}
+@article{Willighagen2016,
+    title={Migrating pKa data from DrugMet to Wikidata},
+    author={Egon Willighagen},
+    journal={chem-bla-ics},
+    year={2016},
+    month={mar},
+    url={http://chem-bla-ics.blogspot.de/2016/03/migrating-pka-data-from-drugmet-to.html}
+}
+@article{Hartmann2015,
+    title={Paul Otlets Hypermedium. Dokumentation als Gegenidee zur Bibliothek},
+    author={Frank Hartmann},
+    journal={LIBREAS. Library Ideas},
+    number={28},
+    year = {2015},
+    url={http://libreas.eu/ausgabe28/04hartmann/}
+}
+@techreport{Putman2015,
+  doi = {10.1101/031286},
+  url = {http://dx.doi.org/10.1101/031286},
+  year  = {2015},
+  month = {nov},
+  publisher = {Cold Spring Harbor Laboratory Press},
+  author = {T. Putman and S. Burgstaller and A. Waagmeester and C. Wu and A. I. Su and B. Good},
+  title = {Centralizing content and distributing labor: a community model for curating the very long tail of microbial genomes.}
+}
+@article{Wiki4R,
+    doi = {10.3897/rio.1.e7573},
+    url = {http://dx.doi.org/10.3897/rio.1.e7573},
+    year = 2015,
+    month = {dec},
+    publisher = {Pensoft Publishers},
+    volume = {1},
+    pages = {e7573},
+    author = {Daniel Mietchen and Gregor Hagedorn and Egon Willighagen and Mariano Rico and Asunción Gómez-Pérez and Eduard Aibar and Karima Rafes and Cécile Germain and Alastair Dunning and Lydia Pintscher and Daniel Kinzler},
+    title = {Enabling Open Science: Wikidata for Research (Wiki4R)},
+    journal = {Research Ideas and Outcomes}
+} 
+

--- a/voss2/master.md
+++ b/voss2/master.md
@@ -1,0 +1,108 @@
+# Ein gescheiterter Fachartikel
+
+Als ich den Call for Papers für die
+[LIBREAS](http://www.wikidata.org/entity/Q1798120)^[Die Hyperlinks im Text
+verweisen auf entsprechende Wikidata-Items oder -Projektseiten.]-Ausgabe #29
+"Bibliographien" zur Kenntnis nahm, war sofort klar: ich muss unbedingt etwas
+zu einem Thema einreichen, dass mir schon länger auf den Nägeln brennt. Wie
+[Wikipedia](http://www.wikidata.org/entity/Q52), deren Aufstieg ich vor rund
+zehn Jahren intensiv mit Vorträgen, Publikationen und nicht zuletzt mit aktiver
+Teilnahme begleitete, geht es wieder um ein Projekt der [Wikimedia
+Foundation](http://www.wikidata.org/entity/Q180), und zwar um
+[Wikidata](http://www.wikidata.org/entity/Q2013). Wieder habe ich das Gefühl,
+dass hier eine Entwicklung stattfinden, die eine der Kernaufgabe von
+Bibliotheken tangiert, aber in ihrer Tragweite von der [Bibliotheks- und
+Informationswissenschaftlichen](http://www.wikidata.org/entity/Q13420675)
+Fachcommunity noch nicht so richtig wahrgenommen wird. Wieder versuche ich zum
+Thema zu publizieren und nehme an der Entwicklung regen Anteil. Im Gegensatz zu
+vor zehn Jahren ist mein Anteil am Wikidata-Projekt jedoch durch berufliche und
+familiäre Verpflichtungen beschränkt und vielleicht fehlt mir auch etwas die
+naive Unverfrorenheit, die so hilfreich ist um andere für ein Projekt wie
+Wikipedia oder Wikidata zu begeistern.
+
+Inzwischen habe ich den mittlerweile dritten Entwurf eines
+[Fachartikels](http://www.wikidata.org/entity/Q591041) mit dem Titel "Wikidata
+als Universalbibliographie" abgebrochen, während die Ideen, Notizen, und offene
+Browsertabs zum Thema immer mehr werden. Falls jemand mit dem Gedanken einer
+Masterarbeit, Promotion oder eines Forschungsprojektes zum Thema spielt, möge
+sie oder er sich bitte bei mir melden. Ein Grundproblem besteht in der
+Geschwindigkeit mit der sich Wikidata im Allgemeinen und die Sammlung von
+bibliographischen Daten in/mit Wikidata im Speziellen entwickelt.
+
+# Wikidata als Universalbibliographie
+
+Um es kurz zu machen, möchte ich an dieser Stelle nur meine Einschätzung
+abgeben: *Wikidata hat das Potential für Bibliographien verleichbares zu
+leisten wie Wikipedia für allgemeine Nachschlagewerke*. Mit allen Vor- und
+Nachteilen.[^2][^3] Insbesondere ist seit Paul Otlets [Répertoire
+bibliographique universel](http://www.wikidata.org/entity/Q3456262) das Ziel
+einer wirklichen Universalbibliographie erstmals wieder in greifbare Nähe
+gerückt.[^4]  Diese Einschätzung basiert nicht nur auf meiner allgemeinen Erfahrung
+mit Wikipedia, Wikidata, Social Cataloging, bibligraphischen Datenformaten und
+Datenbanken etc., sondern kann auch durch einige Indizien belegt werden:
+
+[^2]: Diese Vor- und Nachteile wären unter Anderem Gegenstand einer
+genaueren Untersuchung der tatsächlichen und prognostizierten Rolle von
+Wikidata für Bibliographien.
+
+[^3]: Für den Bereich der Normdaten ist Wikidata übrigens von ähnlicher
+Bedeutung, dies ist aber ein anderes Thema (vgl. @Voss2014).
+
+[^4]: Siehe @Hartmann2015 für eine Auseinandersetzung mit Otlets Projekt in LIBREAS,
+aus der bereits der Datenbank-Charakter dieser Universalbibliographie hervorgeht.
+
+* Dank ihres flexiblen Datenmodells lassen sich bereits jetzt bibliographische
+  Daten in Wikidata eintragen. Zur Koordinierung gibt es verschiedene Projekte
+  innerhalb von Wikidata ([WikiProject Books](https://www.wikidata.org/wiki/Wikidata:WikiProject_Books),
+  [WikiProject Periodicals](https://www.wikidata.org/wiki/Wikidata:WikiProject_Periodicals),
+  [WikiProject Source MetaData](https://www.wikidata.org/wiki/Wikidata:WikiProject_Source_MetaData)...).
+  Wie in Wikipedia gibt es allerdings keine
+  zentrale Koordination, so dass von verschiedener Seite bibliographische 
+  Angaben in Wikidata einfließen.[^5]
+
+
+[^5]: Ein einfaches Beispiel ist die von @Willighagen2016 beschriebene
+Migration seiner Datenbank zu Wikidata: Zwischen 2010 und 2016 sammelten Egon
+Willighagen und Samuel Lampa die Säurekonstante ($pK_a$) verschiedener
+chemischer Substanzen in einer Datenbank. Jeder Eintrag besteht aus dem
+International Chemical Identifier  (InChI), einem Messwert und einer
+Fachpublikation in welcher der Messwert publiziert wurde. In Wikidata würden im
+Rahem des Umzugs der Datenbank nach Wikidata für alle Fachpublikationen
+einzelne Wikidata-Einträge angelegt.
+
+
+* Während beim Social Cataloging herkömmlicherweise jedeR NutzerIn eine eigene
+  Bibliographie pflegt ("bag-model") arbeiten in Wikidata alle gemeinsam an einem
+  Datenbestand ("set-model"), ähnlich wie bei einem Verbundkatalog.
+
+* Verglichen mit bibliothekarischer Verbundkatalogisierung ist die Hürde Fehler
+  zu beseitigen oder Ergänzungen vorzunehmen in Wikidata allerdings ungleich 
+  niedriger. Während die Mittel von Bibliotheken eher begrenzt sind, ist bei 
+  Wikidata von einer weiter wachsenden Zahl von Beitragenden auszugehen.
+
+* Die umfangreiche Verfügbarkeit der Inhalte von Wikidata über verschiedene
+  Schnittstellen ermöglicht es, qualifizierte Aussagen über die Datenqualität
+  zu treffen und diese so kontrolliert zu verbessern.
+
+* Als universelle Datenbank ist Wikidata nicht auf bibliographische Daten
+  beschränkt. Das Prinzip der Verknüpfung mit
+  [Normdaten](http://www.wikidata.org/entity/Q6423319) lässt sich so auf die
+  Spitze treiben und ermöglicht bibliometrische und weitere Auswertungen, die
+  mit anderen Katalogen nur schwer möglich sind.
+
+* Wikidata ist weder kommerziellen noch politischen Interessen unterworfen, die
+  die Entwicklung von (Universal)bibliographien in anderen Bereichen behindern.
+
+* Die Verwendung von Wikidata für die Wissenschaft wird auch in anderen Bereichen
+  vorangetrieben. Der Antrag zum EU-Projekt Wikidata for Research (Wiki4R) gibt
+  einen guten Überblick über die zu erwartende Entwicklung [@Wiki4R].
+
+* Ende Mai findet in Berlin die [WikiCite-Tagung](https://meta.wikimedia.org/wiki/WikiCite_2016) 
+  mit 50 ExpertInnen statt, um einen konkreten Plan für die Umsetzung der Migration aller Quellenanaben
+  aus Wikipedia nach Wikidata festzulegen.
+
+Es kann also davon ausgegangen werden, dass alle die sich mit der Sammlung
+bibliographischer Daten beschäftigen mit Wikidata "[in interessanten Zeiten
+leben](http://www.wikidata.org/entity/Q14634108)" werden.
+
+# Literaturangaben

--- a/voss2/meta.yaml
+++ b/voss2/meta.yaml
@@ -1,0 +1,16 @@
+---
+layout: page
+lang: "de"
+journal: "LIBREAS. Library Ideas"
+issue: "29"
+year: "2016"
+contributor: 
+- "Jakob Voß"
+title: "Wikidata als Universalbibliographie: ein Kommentar"
+abstract: "Der Kommentar weist auf die Bedeutung von Wikidata für die Entwicklung einer Universalbibliographie hin."
+urn:
+date: 
+comments: false
+sharing: true
+footer: true
+...


### PR DESCRIPTION
Der angekündigte Artikel zu **Wikidata als Universalbibliographie** ist wie im Text beschrieben nicht wie geplant zu Stande gekommen und deshalb als Kommtar oder Leserbrief konzipiert. Ich hoffe ihr nehmt in trotzdem mit auf! Die Einbindung der Literaturangaben erfolgt wie bei dem ersten Artikel
mittels Pandoc.
